### PR TITLE
在 applySecurity 函數中，針對需要登入的路徑加上 Cache-Control

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -158,7 +158,20 @@ function applySecurity(req: NextRequest) {
         res.headers.set('X-Forwarded-For', clientIP);
         res.headers.set('X-Client-IP', clientIP);
     }
+    const cleanedPath = req.nextUrl.pathname.replace(
+        new RegExp(`^${process.env.NEXT_PUBLIC_BASE_PATH || ""}`), 
+        ""
+    );
+    const isPublicPath = PUBLIC_PATHS.some(path => cleanedPath.startsWith(path)) ||
+        cleanedPath.match(/\.(svg|png|jpg|jpeg|webp|ico|woff2|xlsx|txt|xml?)$/);
 
+        // 🔥 如果不是公開路徑，設定不快取
+    if (!isPublicPath) {
+        res.headers.set('Cache-Control', 'private, no-cache, no-store, must-revalidate');
+        res.headers.set('Pragma', 'no-cache');
+        res.headers.set('Expires', '0');
+    }
+    
     if (req.headers.get('host')?.includes('localhost')) {
         return NextResponse.next();
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -170,6 +170,7 @@ function applySecurity(req: NextRequest) {
         res.headers.set('Cache-Control', 'private, no-cache, no-store, must-revalidate');
         res.headers.set('Pragma', 'no-cache');
         res.headers.set('Expires', '0');
+        res.headers.set('Surrogate-Control', 'no-store');
     }
     
     if (req.headers.get('host')?.includes('localhost')) {


### PR DESCRIPTION
Add cache control headers for non-public paths
在 applySecurity 函數中，針對需要登入的路徑加上 Cache-Control
避免 CDN 快取使用者專屬內容
防止登出後還能看到舊資料
保護隱私資料不被中間節點儲存
Surrogate-Control：明確告訴 CDN 不要快取